### PR TITLE
Now passing JSHint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "node": true,
+  "laxcomma": true
+}

--- a/tests/bisection.test.js
+++ b/tests/bisection.test.js
@@ -33,4 +33,4 @@ module.exports = {
     bisection.left(large, 0).should.equal(14);
     bisection.left(large, 232424).should.equal(0);
   }
-}
+};


### PR DESCRIPTION
I applied [JSHint](http://jshint.com) to look for potential sources of bugs. JSHint only gave 9 warnings. The first one was related to `"use strict"`, the solution was to inform JSHint that the code in question is Node.js code (`"node": true` in `.jshintrc`).

Six more warnings were related to comma style. I noticed that you like to use a different comma style, so I tweaked `.jshintrc` some more. After that, all JSHint could complain about was a missing semicolon, so I added it.

Now node-bisection passes JSHint linting!
