### PR TITLE
should return the value if the value exists in the sorted array

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ function bisection(array, x, low, high){
   while (low < high) {
     mid = (low + high) >> 1;
 
+    if(x === array[mid])
+      return mid;
     if (x < array[mid]) {
       high = mid;
     } else {

--- a/tests/bisection.test.js
+++ b/tests/bisection.test.js
@@ -12,6 +12,7 @@ module.exports = {
      bisection.should.equal(bisection.right);
   }
 , 'Bisection right': function(){
+    bisection(small, 3).should.equal(3);
     bisection(small, 4).should.equal(4);
     bisection(small, 15).should.equal(9);
     bisection(small, 4, 5).should.equal(5);


### PR DESCRIPTION
Should bisection return the value's index if the value exists in the sorted array? I encountered the issue when I try to share some data between Nodejs app and Java via Memcache. There are some certain mount cache miss due to this issue. Java is using the value's index but Nodejs is using the values's index+1 to find a node server.

Have another question, does the method left need to be changed, if you plan to merge the fix?

Thank you!
